### PR TITLE
use Gradle Daemon

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,12 +14,12 @@ install:
   - pip install codecov --user
 
 build_script:
-  - ./gradlew assemble --no-daemon
+  - ./gradlew assemble 
 test_script:
-  - ./gradlew check --no-daemon
+  - ./gradlew check 
 
 on_success:
-  - ./gradlew jacocoTestReport --no-daemon
+  - ./gradlew jacocoTestReport 
   - python -m codecov -f build\reports\jacoco\test\jacocoTestReport.xml -F windows
 
 cache:


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
